### PR TITLE
where.like should: [ 'accept', 'array' ]

### DIFF
--- a/lib/active_record/like.rb
+++ b/lib/active_record/like.rb
@@ -4,18 +4,29 @@ module ActiveRecord
   module QueryMethods
     module Like
       def like(opts, *rest)
-        chain_node(Arel::Nodes::Matches, opts, *rest)
+        chain_node(Arel::Nodes::Matches, opts, *rest) do |nodes|
+          nodes.inject { |memo, node| Arel::Nodes::Or.new(memo, node) }
+        end
       end
 
       def not_like(opts, *rest)
-        chain_node(Arel::Nodes::DoesNotMatch, opts, *rest)
+        opts = opts.reject { |_, v| v.is_a?(Array) && v.empty? }
+        chain_node(Arel::Nodes::DoesNotMatch, opts, *rest) do |nodes|
+          Arel::Nodes::And.new(nodes)
+        end
       end
 
     private
-      def chain_node(node_type, opts, *rest)
+
+      def chain_node(node_type, opts, *rest, &block)
         @scope.tap do |s|
           s.where_values += s.send(:build_where, opts, *rest).map do |r|
-            node_type.new(r.left, r.right)
+            if r.right.is_a?(Array)
+              nodes = r.right.map { |expr| node_type.new(r.left, expr) }
+              Arel::Nodes::Grouping.new block.call(nodes)
+            else
+              node_type.new(r.left, r.right)
+            end
           end
         end
       end

--- a/test/integration/like_test.rb
+++ b/test/integration/like_test.rb
@@ -34,6 +34,20 @@ describe ActiveRecord::QueryMethods::WhereChain do
       Post.where.like(title: '%this title is not used anywhere%').map(&:id).wont_include 2
     end
 
+    describe "array behavior" do
+      it "finds records with attributes matching multiple criteria" do
+        Post.where.like(title: ['%DSLs%', 'We need some%']).map(&:id).must_equal [1, 2]
+      end
+
+      it "finds records with attributes matching one criterion" do
+        Post.where.like(title: ['%there?']).map(&:id).must_equal [2]
+      end
+
+      it "does not find any records with an empty array" do
+        Post.where.like(title: []).must_be_empty
+      end
+    end
+
     describe "security-related behavior"  do
       before do
         @user_input = "unused%' OR 1=1); -- "
@@ -48,6 +62,10 @@ describe ActiveRecord::QueryMethods::WhereChain do
 
       it "prevents SQL injection" do
         Post.where.like(title: @user_input).count.must_equal(0)
+      end
+
+      it "prevents SQL injection when provided an array" do
+        Post.where.like(title: [@user_input]).count.must_equal(0)
       end
     end
   end

--- a/test/integration/not_like_test.rb
+++ b/test/integration/not_like_test.rb
@@ -34,6 +34,20 @@ describe ActiveRecord::QueryMethods::WhereChain do
       Post.where.not_like(title: '%this title is not used anywhere%').map(&:id).must_include 2
     end
 
+    describe "array behavior" do
+      it "finds records with attributes not matching multiple criteria" do
+        Post.where.not_like(title: ['%DSLs%', 'We need some%']).map(&:id).must_be_empty
+      end
+
+      it "finds records with attributes not matching one criterion" do
+        Post.where.not_like(title: ['%there?']).map(&:id).must_equal [1]
+      end
+
+      it "finds all records with an empty array" do
+        Post.where.not_like(title: []).count.must_equal 2
+      end
+    end
+
     describe "security-related behavior"  do
       before do
         @user_input = "unused%' OR 1=1); -- "
@@ -49,7 +63,10 @@ describe ActiveRecord::QueryMethods::WhereChain do
       it "prevents SQL injection" do
         Post.where.not_like(title: @user_input).count.must_equal(2)
       end
+
+      it "prevents SQL injection when provided an array" do
+        Post.where.not_like(title: [@user_input]).count.must_equal(2)
+      end
     end
   end
 end
-


### PR DESCRIPTION
This PR adds the ability to query a field based on multiple search terms. This is especially useful when dealing with multi-word searches. If I type "foo bar" in a search box, I might want to see anything that matches either "foo" or "bar".

```
User.where.like(name: ['%foo%, '%bar%'])
=> SELECT "users".* FROM "users" WHERE (("users"."name" LIKE '%foo%' OR "users"."name" LIKE '%bar%'))

User.where.not_like(name: ['%foo%, '%bar%'])
=> SELECT "users".* FROM "users" WHERE (("users"."name" NOT LIKE '%foo%' AND "users"."name" NOT LIKE '%bar%'))
```

The Arel stuff comes from `matches_any` and `does_not_match_all` from [Arel::Predications](https://github.com/rails/arel/blob/master/lib/arel/predications.rb)

The assumption is made that if you're doing a `like` query, you want to use 'OR'. If you're doing a `not_like` query, you want to use 'AND'. I would think this is most often a safe bet, but maybe it would be a good idea to accept an options hash to override that assumption.
